### PR TITLE
Text cursor no longer constantly jumps around, as defaultValue makes …

### DIFF
--- a/src/components/UploadModal.js
+++ b/src/components/UploadModal.js
@@ -236,7 +236,7 @@ export default UploadModal = ({
                         <TextInput
                             label="Walk description"
                             multiline={true}
-                            value={formData.walkDescription}
+                            defaultValue={formData.walkDescription}
                             onChangeText={(text) => handleInputChange("walkDescription", text)}
                             style={styles.formInput}
                             accessibilityLabel="Walk description"


### PR DESCRIPTION
…it so that it does not re-render every time state changes. This has been changed from 'value' as 'value' is tied to the components state, so every time the user types the onChangeText event triggers a state update which causes the component to re-render